### PR TITLE
Search Content-Type for application/json

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -70,7 +70,11 @@ impl Client {
 					"Content-Length" => {
 						content_len = sp[1].parse().unwrap();
 					}
-					"Content-Type" => (),
+					"Content-Type" => {
+						if sp[1].contains("application/json") {
+							panic!("content-type header set but doesn't contain application/json, {}", sp[1]);
+						}
+					},
 					_ => {
 						panic!("unrecognized header: {}", sp[0]);
 					}

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -70,6 +70,7 @@ impl Client {
 					"Content-Length" => {
 						content_len = sp[1].parse().unwrap();
 					}
+					"Content-Type" => (),
 					_ => {
 						panic!("unrecognized header: {}", sp[0]);
 					}

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -74,7 +74,7 @@ impl Client {
 						if sp[1] != "application/vscode-jsonrpc; charset=utf-8" {
 							panic!("unexpected content-type: {}", sp[1]);
 						}
-					},
+					}
 					_ => {
 						panic!("unrecognized header: {}", sp[0]);
 					}

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -71,8 +71,8 @@ impl Client {
 						content_len = sp[1].parse().unwrap();
 					}
 					"Content-Type" => {
-						if sp[1].contains("application/json") {
-							panic!("content-type header set but doesn't contain application/json, {}", sp[1]);
+						if sp[1] != "application/vscode-jsonrpc; charset=utf-8" {
+							panic!("unexpected content-type: {}", sp[1]);
 						}
 					},
 					_ => {


### PR DESCRIPTION
Not supporting `Content-Type` causes `ocaml-lsp` to crash since it sets that header.

Thanks for building this!